### PR TITLE
Add support for rollup-plugin-node-resolve's `browser` option

### DIFF
--- a/src/get-rollup-options.js
+++ b/src/get-rollup-options.js
@@ -70,7 +70,8 @@ export default function (options, format) {
     plugins.push(
       require('rollup-plugin-node-resolve')({
         skip: options.skip,
-        jsnext: options.jsnext
+        jsnext: options.jsnext,
+        browser: options.browser
       }),
       require('rollup-plugin-commonjs')()
     )

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ const cli = meow(`
     --compress          Generate an extra compressed file suffixed with \`.min\` and sourcemap
     --skip              Exclude specfic modules in node_modules dir from bundled file
     --jsnext            Respect jsnext field in package.json as resolving node_modules
+    --browser           Respect browser field in package.json as resolving node_modules
     --alias             Add alias option
     --replace           Add replace option
     --flow              Remove flow type annotations


### PR DESCRIPTION
Hi and thanks for a great and easy to use module! A perfect preconfigured rollup for me :)

This PR adds support for rollup-plugin-node-resolve's `browser` option, to be able to respect a package.json's `browser` field.